### PR TITLE
Fix rake task with option

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -14,7 +14,7 @@ Add the following codes to your Gemfile:
 
 <pre>
 group :development, :test do
-  gem 'test-unit-rails'
+  gem 'test-unit-rails', require: false
 end
 </pre>
 


### PR DESCRIPTION
If we use rake tasks with option (`bundle exec rake db:create --trace`),
`--trace` option captured by Test::Unit automatic runner.

```
invalid option: --trace
Test::Unit automatic runner.
Usage: /home/mtsmfm/.rbenv/versions/2.3.0/bin/rake [options] [-- untouched arguments]
    -r, --runner=RUNNER              Use the given RUNNER.
...
```