### PR TITLE
include rake files to pkg

### DIFF
--- a/test-unit-rails.gemspec
+++ b/test-unit-rails.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
   spec.license = "LGPLv2 or later"
   spec.files = ["COPYING", "Gemfile", "Rakefile", "README.textile"]
   spec.files += Dir.glob("lib/**/*.rb")
+  spec.files += Dir.glob("lib/**/*.rake")
   spec.files += Dir.glob("doc/text/**/*.textile")
   spec.test_files = Dir.glob("test/**/*.rb")
 


### PR DESCRIPTION
I tried to use `test-unit-rails` 5.0.0, but raised `LoadError`. 

stacktrace is as follows:

```
$ ./bin/rails db:migrate
rails aborted!
LoadError: cannot load such file -- test/unit/rails/testing.rake
/home/yaginuma/program/rails/master_y_yagi/rails/railties/lib/rails/railtie.rb:240:in `instance_exec'
/home/yaginuma/program/rails/master_y_yagi/rails/railties/lib/rails/railtie.rb:240:in `block in run_tasks_blocks'
/home/yaginuma/program/rails/master_y_yagi/rails/railties/lib/rails/railtie.rb:248:in `each'
/home/yaginuma/program/rails/master_y_yagi/rails/railties/lib/rails/railtie.rb:248:in `each_registered_block'
/home/yaginuma/program/rails/master_y_yagi/rails/railties/lib/rails/railtie.rb:240:in `run_tasks_blocks'
/home/yaginuma/program/rails/master_y_yagi/rails/railties/lib/rails/application.rb:440:in `block in run_tasks_blocks'
/home/yaginuma/program/rails/master_y_yagi/rails/railties/lib/rails/engine/railties.rb:13:in `each'
/home/yaginuma/program/rails/master_y_yagi/rails/railties/lib/rails/engine/railties.rb:13:in `each'
/home/yaginuma/program/rails/master_y_yagi/rails/railties/lib/rails/application.rb:440:in `run_tasks_blocks'
/home/yaginuma/program/rails/master_y_yagi/rails/railties/lib/rails/engine.rb:457:in `load_tasks'
/home/yaginuma/program/rails/master_with_test_unit/Rakefile:6:in `<top (required)>'
/home/yaginuma/program/rails/master_y_yagi/rails/railties/lib/rails/commands/rake_proxy.rb:12:in `block in run_rake_task'
/home/yaginuma/program/rails/master_y_yagi/rails/railties/lib/rails/commands/rake_proxy.rb:10:in `run_rake_task'
/home/yaginuma/program/rails/master_y_yagi/rails/railties/lib/rails/commands/commands_tasks.rb:51:in `run_command!'
/home/yaginuma/program/rails/master_y_yagi/rails/railties/lib/rails/command.rb:20:in `run'
/home/yaginuma/program/rails/master_y_yagi/rails/railties/lib/rails/commands.rb:18:in `<top (required)>'
./bin/rails:4:in `require'
./bin/rails:4:in `<main>'
(See full trace by running task with --trace)
```

Probably, I think it's had gotten leaks for inclusion in pkg the `test/unit/rails/testing.rake`.
 
