### PR TITLE
test-unit-rails mistakenly assumes that all Rails app uses Active Record

### DIFF
--- a/lib/test/unit/rails/test_help.rb
+++ b/lib/test/unit/rails/test_help.rb
@@ -62,9 +62,12 @@ class ActionController::TestCase
   setup do
     @routes = Rails.application.routes
   end
-  include ActiveRecord::TestFixtures
 
-  self.fixture_path = "#{Rails.root}/test/fixtures/"
+  if defined?(ActiveRecord::Base)
+    include ActiveRecord::TestFixtures
+
+    self.fixture_path = "#{Rails.root}/test/fixtures/"
+  end
 end
 
 class ActionDispatch::IntegrationTest


### PR DESCRIPTION
I tried to run test on my Rails app that doesn't use Active Record, then I got the following errors.

> uninitialized constant ActionController::TestCase::ActiveRecord (NameError)

> undefined method `fixture_path=' for ActionController::TestCase:Class (NoMethodError)

Here's a fix to load `ActiveRecord::TestFixtures` and set `ActionController::TestCase.fixture_path` only when Active Record is loaded.