### PR TITLE
AS::TestCase might not always include Testing::FileFixtures

### DIFF
--- a/lib/test/unit/rails/test_help.rb
+++ b/lib/test/unit/rails/test_help.rb
@@ -42,7 +42,7 @@ if defined?(ActiveRecord::Migration)
 end
 
 class ActiveSupport::TestCase
-  self.file_fixture_path = "#{Rails.root}/test/fixtures/files"
+  self.file_fixture_path = "#{Rails.root}/test/fixtures/files" if respond_to?(:file_fixture_path=)
 end
 
 if defined?(ActiveRecord::Base)


### PR DESCRIPTION
This patch brings Rails < 5 support back together with https://github.com/test-unit/test-unit-activesupport/pull/12.