### PR TITLE
Support case not using Puma in Rails 5.1

### DIFF
--- a/gemfiles/rails5.1-without-puma.gemfile
+++ b/gemfiles/rails5.1-without-puma.gemfile
@@ -1,0 +1,24 @@
+# -*- ruby -*-
+#
+# Copyright (C) 2018  Kouhei Sutou <kou@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+source "https://rubygems.org/"
+
+gemspec path: ".."
+
+gem "rails", "< 5.2.0"
+gem "capybara", "~> 2.13"

--- a/lib/test/unit/rails/test_help.rb
+++ b/lib/test/unit/rails/test_help.rb
@@ -38,7 +38,6 @@ require "active_support/testing/constant_lookup"
 require "action_controller"
 require "action_controller/test_case"
 require "action_dispatch/testing/integration"
-require "action_dispatch/system_test_case"
 
 if defined?(ActiveRecord::Migration)
   if ActiveRecord::Migration.respond_to?(:maintain_test_schema!)
@@ -88,14 +87,19 @@ class ActionDispatch::IntegrationTest
   include Capybara::DSL
 end
 
-class ActionDispatch::SystemTestCase
-  setup before: :prepend do
-    self.class.driver.use
-  end
+begin
+  require "action_dispatch/system_test_case"
+rescue LoadError
+else
+  class ActionDispatch::SystemTestCase
+    setup before: :prepend do
+      self.class.driver.use
+    end
 
-  # take screenshot before reset session
-  teardown after: :prepend do
-    take_failed_screenshot
-    Capybara.reset_sessions!
+    # take screenshot before reset session
+    teardown after: :prepend do
+      take_failed_screenshot
+      Capybara.reset_sessions!
+    end
   end
 end

--- a/test/test_system_test_case.rb
+++ b/test/test_system_test_case.rb
@@ -1,23 +1,25 @@
 require "test_helper"
 
-if ENV["TRAVIS"]
-  require "chromedriver/helper"
-  Chromedriver.set_version "2.35"
-end
-
-class TestSystemTestCase < ActionDispatch::SystemTestCase
-  have_browser = ActionDispatch::SystemTesting.const_defined?(:Browser)
-  if have_browser
-    driver = :selenium
-    driven_by driver, using: :headless_chrome, screen_size: [1920, 1080]
-  else
-    driver = :selenium_chrome_headless
-    driven_by driver, screen_size: [1920, 1080]
+if ActionDispatch::SystemTesting.const_defined?(:Server)
+  if ENV["TRAVIS"]
+    require "chromedriver/helper"
+    Chromedriver.set_version "2.35"
   end
 
-  test "render text" do
-    assert_equal(driver, Capybara.current_driver)
-    visit("/items")
-    assert_text("Hello")
+  class TestSystemTestCase < ActionDispatch::SystemTestCase
+    have_browser = ActionDispatch::SystemTesting.const_defined?(:Browser)
+    if have_browser
+      driver = :selenium
+      driven_by driver, using: :headless_chrome, screen_size: [1920, 1080]
+    else
+      driver = :selenium_chrome_headless
+      driven_by driver, screen_size: [1920, 1080]
+    end
+
+    test "render text" do
+      assert_equal(driver, Capybara.current_driver)
+      visit("/items")
+      assert_text("Hello")
+    end
   end
 end


### PR DESCRIPTION
## Description
In Rails 5.1.6, SystemTestCase only support Puma server
because of require "rack/handler/puma" in system_testing/server.rb
https://github.com/rails/rails/blob/5-1-stable/actionpack/lib/action_dispatch/system_testing/server.rb

If application that use test-unit-rails don't use Puma, cannot load
"rack/handler/puma".

Since if Application Rails 5.1.6 and don't use Puma, skip require "action_dispatch/system_test_case" .

In Rails 5.2, this problem is solved.
https://github.com/rails/rails/blob/5-2-stable/actionpack/lib/action_dispatch/system_testing/server.rb