### PR TITLE
Run tests using at_exit

### DIFF
--- a/lib/rails/commands/test/test_command.rb
+++ b/lib/rails/commands/test/test_command.rb
@@ -27,11 +27,17 @@ module Rails
       end
 
       def perform(*)
-        $LOAD_PATH << Rails::Command.root.join("test").to_s
-
-        ARGV.unshift("--exclude=\\Atest_helper\\.rb\\z")
-        ARGV.unshift("--default-test-path=test")
-        exit(Test::Unit::AutoRunner.run(true))
+        Module.new do
+          at_exit do
+            if $!.nil? and Test::Unit::AutoRunner.need_auto_run?
+              $LOAD_PATH << Rails::Command.root.join("test").to_s
+              
+              ARGV.unshift("--exclude=\\Atest_helper\\.rb\\z")
+              ARGV.unshift("--default-test-path=test")
+              exit(Test::Unit::AutoRunner.run(true))
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Because ARGV is not set during command execution on Rails 6.1:
https://github.com/rails/rails/commit/8ec7a2b7aaa

Otherwise, `rails test test/models/foo_test.rb` doesn't work.
