### PR TITLE
Address NameError on triple nested sub_test_case under ActionView::TestCase on Rails 6.1

### DIFF
--- a/lib/test/unit/rails/test_help.rb
+++ b/lib/test/unit/rails/test_help.rb
@@ -84,6 +84,25 @@ class ActionController::TestCase
   end
 end
 
+module TestUnitRails
+  module ActionViewSubTestCase
+    private
+
+    # Monkey-patching sub_test_case not to raise when fetching its default helper module
+    def sub_test_case_class(*)
+      klass = super
+      class << klass
+        define_method :anonymous? do
+          true
+        end
+      end
+      klass
+    end
+  end
+end
+
+ActionView::TestCase.singleton_class.prepend TestUnitRails::ActionViewSubTestCase
+
 class ActionDispatch::IntegrationTest
   setup do
     @routes = Rails.application.routes

--- a/test/test_action_view.rb
+++ b/test/test_action_view.rb
@@ -1,0 +1,11 @@
+require "test_helper"
+
+class TestActionView < ActionView::TestCase
+  sub_test_case "sub 1" do
+    sub_test_case "sub 2" do
+      def test_test_under_double_nexted_sub_test_case_works
+        assert_true true
+      end
+    end
+  end
+end


### PR DESCRIPTION
Since Rails 6.1 (Zeitwerk), all `ActionView::TestCase` class is expected to abide by normal Ruby module naming, but this is not always the case with `sub_test_case` since `sub_test_case` generates an anonymous class with the given string as its `name`.

Attached is a simple reproduction of the situation, and a monkey-patch for `ActionView::TestCase`'s `sub_test_case` to ignore `NameError` from `default_helper_module!`.
It is less likely that this patch introduces any new unexpected bug because that's basically how things were working with older versions of Rails with test-unit.

Please note that this patch depends on [test-unit#207](https://github.com/test-unit/test-unit/pull/207). We need a patched version of test-unit to be bundled to this repo in order for this patch to run (and so I expect that that test I added here would raise errors on the CI for this PR).