### PR TITLE
Bundle webdrivers on Rails 5 tests

### DIFF
--- a/test/test_app.sh
+++ b/test/test_app.sh
@@ -31,6 +31,8 @@ group :development, :test do
   gem "test-unit-rails", path: "/source/"
 end
 GEMFILE
+# For Rails 5 Gemfile
+sed -i'' -e "s/gem 'chromedriver-helper'/gem 'webdrivers'/" Gemfile
 bundle update
 
 sed -i'' -e 's,rails/test_help,test/unit/rails/test_help,g' test/test_helper.rb


### PR DESCRIPTION
Here's a fix for the Rails 5 CI failure
https://github.com/test-unit/test-unit-rails/actions/runs/5255290563/jobs/9495008785#step:3:2858
by replacing unmaintained chromedriver-helper gem with webdrivers gem.