### PR TITLE
Let RAILS_VERSION be `~>6.0.0` when installing 6.0.x

### DIFF
--- a/dockerfiles/ruby.dockerfile
+++ b/dockerfiles/ruby.dockerfile
@@ -21,6 +21,6 @@ RUN \
   rm -rf /var/lib/apt/lists/*
 
 ARG RAILS_VERSION
-RUN gem install rails -v "~>${RAILS_VERSION}"
+RUN gem install rails -v "~>${RAILS_VERSION}.0"
 
 CMD /source/test/test_app.sh


### PR DESCRIPTION
I noticed that the Rails 6.0 container test was actually installing and running Rails 6.1
https://github.com/test-unit/test-unit-rails/actions/runs/5261490756/jobs/9509654355
because it installs rails `"~>6.0"`.

It indeed has to be `"~>6.0.0"` to install version 6.0.x.