### PR TITLE
Bring back Rails 5.1 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,15 @@ jobs:
           - name: "Ruby 2.5 & Rails 5"
             ruby-version: "2.5"
             rails-version: "5"
+          - name: "Ruby 2.7 & Rails 5.1"
+            ruby-version: "2.7"
+            rails-version: "5.1"
+          - name: "Ruby 2.6 & Rails 5.1"
+            ruby-version: "2.6"
+            rails-version: "5.1"
+          - name: "Ruby 2.5 & Rails 5.1"
+            ruby-version: "2.5"
+            rails-version: "5.1"
     env:
       BUNDLE_GEMFILE: gemfiles/rails${{ matrix.rails-version }}.gemfile
       DISPLAY: ":99.0"
@@ -76,6 +85,7 @@ jobs:
           - "6"
           - "6.0"
           - "5"
+          - "5.1"
     steps:
       - uses: actions/checkout@v3
       - name: Test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,3 +40,13 @@ services:
         RAILS_VERSION: 5
     volumes:
       - .:/source:delegated
+
+  ruby-2.7-rails-5.1:
+    build:
+      context: .
+      dockerfile: dockerfiles/ruby.dockerfile
+      args:
+        FROM: ruby:2.7
+        RAILS_VERSION: 5.1
+    volumes:
+      - .:/source:delegated

--- a/gemfiles/rails5.1.gemfile
+++ b/gemfiles/rails5.1.gemfile
@@ -1,0 +1,26 @@
+# -*- ruby -*-
+#
+# Copyright (C) 2018-2019  Sutou Kouhei <kou@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+source "https://rubygems.org/"
+
+gemspec path: ".."
+
+gem "rails", "< 5.2.0"
+gem "puma"
+gem "capybara", "~> 2.13"
+gem "sqlite3", "~> 1.3.6"

--- a/test-unit-rails.gemspec
+++ b/test-unit-rails.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.files += Dir.glob("doc/text/**/*.md")
   spec.test_files = Dir.glob("test/**/*.rb")
 
-  spec.add_runtime_dependency("rails", ">= 5.2.0")
+  spec.add_runtime_dependency("rails", ">= 5.1.0")
   spec.add_runtime_dependency("test-unit-activesupport", ">= 1.0.8")
   spec.add_runtime_dependency("test-unit-capybara", ">= 1.0.5")
   spec.add_runtime_dependency("test-unit-rr", ">= 1.0.4")


### PR DESCRIPTION
Here's my first attempt to bring back legacy versions support.

This patch simply picks the gemfile from 015343e62f89d5ef2090d0a3c4af8c66278151cf ( `git show df9743c` ) then adds the CI entry, and I'm expecting it to just work.