### PR TITLE
Bring Back Rails 5.0 Support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,15 @@ jobs:
           - name: "Ruby 2.5 & Rails 5.1"
             ruby-version: "2.5"
             rails-version: "5.1"
+          - name: "Ruby 2.7 & Rails 5.0"
+            ruby-version: "2.7"
+            rails-version: "5.0"
+          - name: "Ruby 2.6 & Rails 5.0"
+            ruby-version: "2.6"
+            rails-version: "5.0"
+          - name: "Ruby 2.5 & Rails 5.0"
+            ruby-version: "2.5"
+            rails-version: "5.0"
     env:
       BUNDLE_GEMFILE: gemfiles/rails${{ matrix.rails-version }}.gemfile
       DISPLAY: ":99.0"
@@ -86,6 +95,7 @@ jobs:
           - "6.0"
           - "5"
           - "5.1"
+          - "5.0"
     steps:
       - uses: actions/checkout@v3
       - name: Test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,3 +50,13 @@ services:
         RAILS_VERSION: 5.1
     volumes:
       - .:/source:delegated
+
+  ruby-2.7-rails-5.0:
+    build:
+      context: .
+      dockerfile: dockerfiles/ruby.dockerfile
+      args:
+        FROM: ruby:2.7
+        RAILS_VERSION: 5.0
+    volumes:
+      - .:/source:delegated

--- a/dockerfiles/ruby.dockerfile
+++ b/dockerfiles/ruby.dockerfile
@@ -22,5 +22,6 @@ RUN \
 
 ARG RAILS_VERSION
 RUN gem install rails -v "~>${RAILS_VERSION}.0"
+ENV RAILS_VERSION ${RAILS_VERSION}
 
 CMD /source/test/test_app.sh

--- a/dockerfiles/ruby.dockerfile
+++ b/dockerfiles/ruby.dockerfile
@@ -12,6 +12,7 @@ RUN \
 RUN \
   apt update && \
   apt install -y -V \
+    bc \
     chromium-driver \
     chromium-sandbox \
     nodejs \

--- a/gemfiles/rails5.0.gemfile
+++ b/gemfiles/rails5.0.gemfile
@@ -1,0 +1,26 @@
+# -*- ruby -*-
+#
+# Copyright (C) 2018-2019  Sutou Kouhei <kou@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+source "https://rubygems.org/"
+
+gemspec path: ".."
+
+gem "rails", "< 5.1.0"
+gem "puma"
+gem "capybara", "~> 2.13"
+gem "sqlite3", "~> 1.3.6"

--- a/lib/test/unit/rails/testing.rake
+++ b/lib/test/unit/rails/testing.rake
@@ -31,10 +31,12 @@ namespace :test do
     "jobs",
     "system",
   ].each do |component|
-    Rake.application["test:#{component}"].clear_actions
-    task component do
-      path = File.expand_path("test/#{component}")
-      Test::Unit::AutoRunner.run(true, "test", [component])
+    if Rake.application.lookup("test:#{component}")
+      Rake.application["test:#{component}"].clear_actions
+      task component do
+        path = File.expand_path("test/#{component}")
+        Test::Unit::AutoRunner.run(true, "test", [component])
+      end
     end
   end
 

--- a/test-unit-rails.gemspec
+++ b/test-unit-rails.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.files += Dir.glob("doc/text/**/*.md")
   spec.test_files = Dir.glob("test/**/*.rb")
 
-  spec.add_runtime_dependency("rails", ">= 5.1.0")
+  spec.add_runtime_dependency("rails", ">= 5.0.0")
   spec.add_runtime_dependency("test-unit-activesupport", ">= 1.0.8")
   spec.add_runtime_dependency("test-unit-capybara", ">= 1.0.5")
   spec.add_runtime_dependency("test-unit-rr", ">= 1.0.4")

--- a/test/test_app.sh
+++ b/test/test_app.sh
@@ -34,7 +34,7 @@ GEMFILE
 # For Rails 5 Gemfile
 sed -i'' -e "s/gem 'chromedriver-helper'/gem 'webdrivers'/" Gemfile
 # Rails 5.0 doesn't work with sqlite >= 1.4
-if rails --version | grep -Fq "^Rails 5.0"; then
+if [ "${RAILS_VERSION}" = "5.0" ]; then
   sed -i'' -e "s/gem 'sqlite3'/gem 'sqlite3', '~> 1.3.6'/" Gemfile
 fi
 bundle update
@@ -43,7 +43,7 @@ sed -i'' -e 's,rails/test_help,test/unit/rails/test_help,g' test/test_helper.rb
 # TODO: Implement.
 sed -i'' -e 's/parallelize/# parallelize/g' test/test_helper.rb
 
-if rails --version | grep -q "^Rails 6"; then
+if [[ "${RAILS_VERSION}" =~ ^6 ]]; then
   rails webpacker:install
 fi
 rails generate model item name:string

--- a/test/test_app.sh
+++ b/test/test_app.sh
@@ -33,6 +33,10 @@ end
 GEMFILE
 # For Rails 5 Gemfile
 sed -i'' -e "s/gem 'chromedriver-helper'/gem 'webdrivers'/" Gemfile
+# Rails 5.0 doesn't work with sqlite >= 1.4
+if rails --version | grep -Fq "^Rails 5.0"; then
+  sed -i'' -e "s/gem 'sqlite3'/gem 'sqlite3', '~> 1.3.6'/" Gemfile
+fi
 bundle update
 
 sed -i'' -e 's,rails/test_help,test/unit/rails/test_help,g' test/test_helper.rb

--- a/test/test_app.sh
+++ b/test/test_app.sh
@@ -49,6 +49,16 @@ fi
 rails generate model item name:string
 sed -i'' -e 's/# //g' test/models/item_test.rb
 rails db:migrate
-rails test -v | tee test.log
-grep models: test.log
-grep assertions test.log
+
+if [ $(echo "${RAILS_VERSION} >= 5.1" | bc) -eq 1 ]; then
+  # Test with `rails test` command
+  rails test -v | tee test.log
+  grep models: test.log
+  grep assertions test.log
+else
+  # Test with legacy `rake test` task
+  rake test:models -v | tee test.log
+  grep "1 assertions" test.log
+  rake test -v | tee test.log
+  grep assertions test.log
+fi


### PR DESCRIPTION
This patch brings Rails 5.0 support back, with a little bit of code complexity in the testing script.

In my opinion the complexity is an acceptable trade-off for the wider versions support, but I'd like to hear @kou's opinion if I'm in the right direction.