### PR TITLE
Bring Back Rails 4.2 Support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,15 +89,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rails-version:
-          - "7"
-          - "6"
-          - "6.0"
-          - "5"
-          - "5.1"
-          - "5.0"
+        include:
+          - ruby-version: "2.7"
+            rails-version: "7"
+          - ruby-version: "2.7"
+            rails-version: "6"
+          - ruby-version: "2.7"
+            rails-version: "6.0"
+          - ruby-version: "2.7"
+            rails-version: "5"
+          - ruby-version: "2.7"
+            rails-version: "5.1"
+          - ruby-version: "2.7"
+            rails-version: "5.0"
     steps:
       - uses: actions/checkout@v3
       - name: Test
         run: |
-          docker-compose run --rm ruby-2.7-rails-${{ matrix.rails-version }}
+          docker-compose run --rm ruby-${{ matrix.ruby-version }}-rails-${{ matrix.rails-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,6 +70,10 @@ jobs:
           - name: "Ruby 2.5 & Rails 5.0"
             ruby-version: "2.5"
             rails-version: "5.0"
+          - name: "Ruby 2.4 & Rails 4.2"
+            ruby-version: "2.4"
+            rails-version: "4.2"
+            bundler_version: 1
     env:
       BUNDLE_GEMFILE: gemfiles/rails${{ matrix.rails-version }}.gemfile
       DISPLAY: ":99.0"
@@ -78,6 +82,8 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
+          rubygems: ${{ (matrix.ruby_version < '2.6' && 'default') || 'latest' }}
+          bundler: ${{ matrix.bundler_version }}
           bundler-cache: true
       - uses: nanasess/setup-chromedriver@v1
       - name: Test
@@ -102,6 +108,8 @@ jobs:
             rails-version: "5.1"
           - ruby-version: "2.7"
             rails-version: "5.0"
+          - ruby-version: "2.4"
+            rails-version: "4.2"
     steps:
       - uses: actions/checkout@v3
       - name: Test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,3 +60,13 @@ services:
         RAILS_VERSION: 5.0
     volumes:
       - .:/source:delegated
+
+  ruby-2.4-rails-4.2:
+    build:
+      context: .
+      dockerfile: dockerfiles/ruby.dockerfile
+      args:
+        FROM: ruby:2.4
+        RAILS_VERSION: 4.2
+    volumes:
+      - .:/source:delegated

--- a/dockerfiles/ruby.dockerfile
+++ b/dockerfiles/ruby.dockerfile
@@ -22,7 +22,11 @@ RUN \
   rm -rf /var/lib/apt/lists/*
 
 ARG RAILS_VERSION
+
+# Ruby 2.4's bundled rubygems is too old that it fails to install rails
+RUN if ruby -v | grep -qF 'ruby 2.4.'; then gem update --system 3.3.26; fi
 RUN gem install rails -v "~>${RAILS_VERSION}.0"
+
 ENV RAILS_VERSION ${RAILS_VERSION}
 
 CMD /source/test/test_app.sh

--- a/gemfiles/rails4.2.gemfile
+++ b/gemfiles/rails4.2.gemfile
@@ -1,0 +1,26 @@
+# -*- ruby -*-
+#
+# Copyright (C) 2023  Akira Matsuda <ronnie@dio.jp>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+source "https://rubygems.org/"
+
+gemspec path: ".."
+
+gem "rails", "< 5.0.0"
+gem "capybara", "~> 2.13"
+gem "sqlite3", "~> 1.3.6"
+gem "loofah", "< 2.21.0"

--- a/test-unit-rails.gemspec
+++ b/test-unit-rails.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.files += Dir.glob("doc/text/**/*.md")
   spec.test_files = Dir.glob("test/**/*.rb")
 
-  spec.add_runtime_dependency("rails", ">= 5.0.0")
+  spec.add_runtime_dependency("rails", ">= 4.2.0")
   spec.add_runtime_dependency("test-unit-activesupport", ">= 1.0.8")
   spec.add_runtime_dependency("test-unit-capybara", ">= 1.0.5")
   spec.add_runtime_dependency("test-unit-rr", ">= 1.0.4")

--- a/test/test_app.sh
+++ b/test/test_app.sh
@@ -58,7 +58,7 @@ if [[ "${RAILS_VERSION}" =~ ^6 ]]; then
 fi
 rails generate model item name:string
 sed -i'' -e 's/# //g' test/models/item_test.rb
-rails db:migrate
+rake db:migrate
 
 if [ $(echo "${RAILS_VERSION} >= 5.1" | bc) -eq 1 ]; then
   # Test with `rails test` command

--- a/test/test_app.sh
+++ b/test/test_app.sh
@@ -43,6 +43,10 @@ sed -i'' -e "s/gem 'chromedriver-helper'/gem 'webdrivers'/" Gemfile
 if [ $(echo "${RAILS_VERSION} < 5.1" | bc) -eq 1 ]; then
   sed -i'' -e "s/gem 'sqlite3'/gem 'sqlite3', '~> 1.3.6'/" Gemfile
 fi
+# Installing rubygems that includes bulndler 1 that is requred by Rails 4
+if [[ "${RAILS_VERSION}" =~ ^4 ]]; then
+  gem update --system 3.0.9
+fi
 bundle update
 
 sed -i'' -e 's,rails/test_help,test/unit/rails/test_help,g' test/test_helper.rb

--- a/test/test_app.sh
+++ b/test/test_app.sh
@@ -31,6 +31,12 @@ group :development, :test do
   gem "test-unit-rails", path: "/source/"
 end
 GEMFILE
+if [[ "${RAILS_VERSION}" =~ ^4 ]]; then
+  cat >> Gemfile <<GEMFILE
+gem 'loofah', '< 2.21.0'
+GEMFILE
+fi
+
 # For Rails 5 Gemfile
 sed -i'' -e "s/gem 'chromedriver-helper'/gem 'webdrivers'/" Gemfile
 # Rails 4.x and 5.0 doesn't work with sqlite >= 1.4

--- a/test/test_app.sh
+++ b/test/test_app.sh
@@ -33,8 +33,8 @@ end
 GEMFILE
 # For Rails 5 Gemfile
 sed -i'' -e "s/gem 'chromedriver-helper'/gem 'webdrivers'/" Gemfile
-# Rails 5.0 doesn't work with sqlite >= 1.4
-if [ "${RAILS_VERSION}" = "5.0" ]; then
+# Rails 4.x and 5.0 doesn't work with sqlite >= 1.4
+if [ $(echo "${RAILS_VERSION} < 5.1" | bc) -eq 1 ]; then
   sed -i'' -e "s/gem 'sqlite3'/gem 'sqlite3', '~> 1.3.6'/" Gemfile
 fi
 bundle update


### PR DESCRIPTION
This patch brings Rails 4.2 support back.

Although no change inside `lib` directory is included this time, this patch contains a little bit tricky hacks in the script for the containers, in order for Ruby 2.4 to install and run Rails 4.2.

The first hack is that we had to update rubygems because Ruby 2.4's default rubygems is too old that it fails to install rails 4.2 by not being able to resolve the gem dependencies. So we're updating the version of rubygems to 3.3.26, the latest version of 3.3.x that supports Ruby 2.4.
However, Rails 2.4 requires bundler 1.x in runtime, and so we have to install bundler 1 as well. I thought we could just `gem install bundler '<2'` (1.17.3 was the last release) and call it with rubygems' version specifier e.g. `bundle _1.17.3_ install`, but strangely, this basic feature of rubygems didn't work on the container environment here for some unknown reason. So instead, I had to downgrade the versions of whole rubygems / bundler pair, this time to the one that includes bundler 1.17.3 i.e. rubygems 3.0.9 (rubygems 3.1.x ships with bundler 2).

This is the whole story of why we're reinstalling different versions of rubygems here and there. Version 3.3 is needed to install rails 4.2, and 3.0 is needed to run it. This is, I guess, the trickiest part of this patch, and the rest is just needed to properly run and pass the tests.
