### PR TITLE
Bring Rails 4.1 (and Ruby 2.3) support back

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,6 +74,10 @@ jobs:
             ruby-version: "2.4"
             rails-version: "4.2"
             bundler_version: 1
+          - name: "Ruby 2.3 & Rails 4.1"
+            ruby-version: "2.3"
+            rails-version: "4.1"
+            bundler_version: 1
     env:
       BUNDLE_GEMFILE: gemfiles/rails${{ matrix.rails-version }}.gemfile
       DISPLAY: ":99.0"
@@ -110,6 +114,8 @@ jobs:
             rails-version: "5.0"
           - ruby-version: "2.4"
             rails-version: "4.2"
+          - ruby-version: "2.3"
+            rails-version: "4.1"
     steps:
       - uses: actions/checkout@v3
       - name: Test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,3 +70,12 @@ services:
         RAILS_VERSION: 4.2
     volumes:
       - .:/source:delegated
+
+  ruby-2.3-rails-4.1:
+    build:
+      context: .
+      dockerfile: dockerfiles/ruby2.3.dockerfile
+      args:
+        RAILS_VERSION: 4.1
+    volumes:
+      - .:/source:delegated

--- a/dockerfiles/ruby2.3.dockerfile
+++ b/dockerfiles/ruby2.3.dockerfile
@@ -1,0 +1,36 @@
+FROM ruby:2.3
+
+RUN \
+  echo "debconf debconf/frontend select Noninteractive" | \
+    debconf-set-selections
+
+RUN \
+  echo 'APT::Install-Recommends "false";' > \
+    /etc/apt/apt.conf.d/disable-install-recommends
+
+# Fetch packages from archive because ruby2.3 image is based on Debian stretch
+RUN \
+  echo "deb http://archive.debian.org/debian stretch main" > \
+    /etc/apt/sources.list
+
+RUN \
+  apt update && \
+  apt upgrade -y && \
+  apt install -y -V \
+    bc \
+    chromium-driver \
+    chromium \
+    nodejs \
+    yarn && \
+  apt clean && \
+  rm -rf /var/lib/apt/lists/*
+
+ARG RAILS_VERSION
+
+# Ruby 2.3's bundled rubygems is too old that it fails to install rails
+RUN gem update --system 3.3.26
+RUN gem install rails -v "~>${RAILS_VERSION}.0"
+
+ENV RAILS_VERSION ${RAILS_VERSION}
+
+CMD /source/test/test_app.sh

--- a/gemfiles/rails4.1.gemfile
+++ b/gemfiles/rails4.1.gemfile
@@ -1,0 +1,26 @@
+# -*- ruby -*-
+#
+# Copyright (C) 2023  Akira Matsuda <ronnie@dio.jp>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+source "https://rubygems.org/"
+
+gemspec path: ".."
+
+gem "rails", "< 4.2.0"
+gem "capybara", "~> 2.13"
+gem "sqlite3", "~> 1.3.6"
+gem "loofah", "< 2.21.0"

--- a/test-unit-rails.gemspec
+++ b/test-unit-rails.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.files += Dir.glob("doc/text/**/*.md")
   spec.test_files = Dir.glob("test/**/*.rb")
 
-  spec.add_runtime_dependency("rails", ">= 4.2.0")
+  spec.add_runtime_dependency("rails", ">= 4.1.0")
   spec.add_runtime_dependency("test-unit-activesupport", ">= 1.0.8")
   spec.add_runtime_dependency("test-unit-capybara", ">= 1.0.5")
   spec.add_runtime_dependency("test-unit-rr", ">= 1.0.4")


### PR DESCRIPTION
This patch brings Rails 4.1 support back, because I found that I'm actually still testing against Rails 4.1 on test-unit-rails in some products that I maintain, and so I would be happier if I can use the newest test-unit-rails for that purpose:
https://github.com/kaminari/kaminari/blob/28b8da596e6cf6be93e567fba293d6966faba73b/.github/workflows/main.yml#L127-L129
https://github.com/asakusarb/action_args/blob/efd34d122e489aeda78d282e093c78ef959f4ef0/.github/workflows/main.yml#L44-L45

This patch is basically a simple one again that includes no change under `lib` directory, but adds another trivial complexity around the docker container for the testing, because

- Rails 4.1 doesn't support Ruby 2.4, so we had to run Ruby 2.3 (or older) in order to run the tests
- the `ruby:2.3` docker image is based on Debian stretch (ruby:2.4 is buster based)
- Debian stretch is already EOLed, so we have to tell the image to retrieve its packages from archive.debian.org
- some packages that we use on buster are not available on stretch and so we have to choose outdated alternatives (chromium-sandbox => chromium, yarnpkg => yarn, etc.)
- so I ended up in creating a separate dedicated docker file for spinning up Ruby 2.3 containers

BTW this PR is going to be the last one for the "bring back old Rails supports" series of patches, because I already found it much more difficult to add Rails 4.0 support (because it depends on very old versions of capybara) and I personally have no actual use case at the moment to run Rails 4.0 on recent versions of test-unit-rails.