### PR TITLE
chromedriver should be already setup on the CI environment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,7 +89,6 @@ jobs:
           rubygems: ${{ (matrix.ruby_version < '2.6' && 'default') || 'latest' }}
           bundler: ${{ matrix.bundler_version }}
           bundler-cache: true
-      - uses: nanasess/setup-chromedriver@v2
       - name: Test
         run: bundle exec rake test
 


### PR DESCRIPTION
`nanasess/setup-chromedriver@v2` seems quite unstable while trying to install chromedriver on our CI, but afaik chromedriver has to be ready to use in the default GHA stack without no such configuration.