### PR TITLE
Monkey-patch ActionView::TestCase only when ActionView is loaded

### DIFF
--- a/lib/test/unit/rails/test_help.rb
+++ b/lib/test/unit/rails/test_help.rb
@@ -109,7 +109,9 @@ module TestUnitRails
   end
 end
 
-ActionView::TestCase.singleton_class.prepend TestUnitRails::ActionViewSubTestCase
+ActiveSupport.on_load :action_view_test_case do
+  ActionView::TestCase.singleton_class.prepend TestUnitRails::ActionViewSubTestCase
+end
 
 class ActionDispatch::IntegrationTest
   setup do


### PR DESCRIPTION
I hit a minor case that tests a Rails-ish app that does not load Action View, and test-unit-rails raises an error here.

And in any case, it'd be better not to directly reference ActionView::TestCase here, but instead wrap the monkey-patch with `ActiveSupport.on_load` hook so that test-unit can skip monkey-patching ActionView::TestCase on apps that do not use this minor class.